### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ directly to an agent as tools or placed behind an MCP server (included). Some us
 * Vibe-code a custom chat UI.
 * Use in non-agentic automations.
 
+<a href="https://glama.ai/mcp/servers/@BenedatLLC/k8stools">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BenedatLLC/k8stools/badge" alt="Kubernetes Tools Server MCP server" />
+</a>
+
 ## Methodology
 
 Our goal is to focus on quality over quantity -- providing
@@ -211,4 +215,3 @@ in this repository's `copilot-instructions.md`:
 > * When providing a status, use an icon show quickly show if it is good or bad.
 > * If you are asked for the current status, and you haven't run a request in
 >   more than an minute, be sure to run the tool again to get the latest status.
-


### PR DESCRIPTION
This PR adds a badge for the [Kubernetes Tools MCP Server](https://glama.ai/mcp/servers/@BenedatLLC/k8stools) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@BenedatLLC/k8stools">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BenedatLLC/k8stools/badge" alt="Kubernetes Tools Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.